### PR TITLE
Codejach/issue#0023

### DIFF
--- a/admin/class-wc-integraciones-admin.php
+++ b/admin/class-wc-integraciones-admin.php
@@ -67,6 +67,8 @@ class Wc_Integraciones_Admin {
 
 		add_action('admin_post' . self::get_meli_auth_suffix() . '_meli_auth_callback', [$this, 'handle_meli_oauth_callback']);
 
+		add_action('rest_api_init', [$this, 'register_sync_toggle_route']);
+
 		$this->ngrok_url = WC_Integraciones_Config::get('api_ngrok_url', '');
 	}
 
@@ -176,7 +178,7 @@ class Wc_Integraciones_Admin {
 				echo '<p>Historial de registros</p>';
 				break;
 			case 'log':
-				echo '<p>Logs del plugin</p>';
+				$this->display_log();
 				break;
 			case 'configuracion':
             	$this->display_configuracion();
@@ -211,6 +213,7 @@ class Wc_Integraciones_Admin {
 				COALESCE(d.available_quantity, p.available_quantity) as available_quantity,
 				COALESCE(d.sold_quantity, p.sold_quantity) as sold_quantity,
 				COALESCE(d.wc_sku, p.wc_sku) as wc_sku,
+				COALESCE(d.sync_stock_enabled, p.sync_stock_enabled) as sync_stock_enabled,
 
 				d.user_product_id,
 				p.logistic_type
@@ -265,6 +268,7 @@ class Wc_Integraciones_Admin {
 					'available_quantity' => $row->available_quantity,
 					'sold_quantity' => $row->sold_quantity,
 					'wc_sku' => $row->wc_sku ?? '',
+					'sync_stock_enabled' => $row->sync_stock_enabled,
 					'variations' => []
 				];
 			}
@@ -280,6 +284,7 @@ class Wc_Integraciones_Admin {
 					'attributes' => $atributos_por_detalle[$row->detalle_id] ?? [],
 					'detalle_id' => $row->detalle_id,
 					'wc_sku' => $row->wc_sku ?? '',
+					'sync_stock_enabled' => $row->sync_stock_enabled,
 				];
 			}
 		}
@@ -717,5 +722,51 @@ class Wc_Integraciones_Admin {
 
 	public static function get_meli_auth_suffix() {
 		return WC_Integraciones_Config::is_prod() ? '' : '_nopriv';
+	}
+
+	/**
+	 * Registrar ruta para activar/desactivar sincronización de SKU
+	 */
+	public function register_sync_toggle_route() {
+		register_rest_route('meli/v1', '/toggle-sync', [
+			'methods' => 'POST',
+			'callback' => [$this, 'handle_toggle_sync'],
+			'permission_callback' => function() {
+				return current_user_can('manage_options');
+			},
+		]);
+	}
+
+	/**
+	 * Callback para el toggle de sincronización
+	 */
+	public function handle_toggle_sync($request) {
+		global $wpdb;
+		$detalle_id = isset($request['detalle_id']) ? intval($request['detalle_id']) : 0;
+		$publicacion_id = isset($request['publicacion_id']) ? intval($request['publicacion_id']) : 0;
+		$enabled = isset($request['enabled']) ? intval($request['enabled']) : 0;
+
+		if ($detalle_id > 0) {
+			$table = $wpdb->prefix . 'wc_integraciones_meli_publicaciones_detalle';
+			$updated = $wpdb->update($table, ['sync_stock_enabled' => $enabled], ['id' => $detalle_id], ['%d'], ['%d']);
+		} else if ($publicacion_id > 0) {
+			$table = $wpdb->prefix . 'wc_integraciones_meli_publicaciones';
+			$updated = $wpdb->update($table, ['sync_stock_enabled' => $enabled], ['id' => $publicacion_id], ['%d'], ['%d']);
+		} else {
+			return new WP_REST_Response(['success' => false, 'message' => 'Faltan parámetros'], 400);
+		}
+
+		return new WP_REST_Response(['success' => (bool)$updated, 'enabled' => $enabled], 200);
+	}
+
+	/**
+	 * Muestra la pestaña de logs
+	 */
+	private function display_log() {
+		global $wpdb;
+		$table = $wpdb->prefix . 'wc_integraciones_meli_log_inventario';
+		$logs = $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 100");
+
+		include_once plugin_dir_path(__FILE__) . 'partials/mercadolibre/log/view.php';
 	}
 }

--- a/admin/js/wc-integraciones-admin.js
+++ b/admin/js/wc-integraciones-admin.js
@@ -1,4 +1,4 @@
-(function( $ ) {
+(function ($) {
 	'use strict';
 
 	/**
@@ -28,18 +28,18 @@
 	 * Although scripts in the WordPress core, Plugins and Themes may be
 	 * practising this, we should strive to set a better example in our own work.
 	 */
-	
-    $(document).ready(function() {
-        const $toggleBtn = $('#toggle_secret');
-        const $secretField = $('#meli_secret_key');
 
-        if ($toggleBtn.length && $secretField.length) {
-            $toggleBtn.on('click', function() {
-                const isPassword = $secretField.attr('type') === 'password';
-                $secretField.attr('type', isPassword ? 'text' : 'password');
-                $(this).text(isPassword ? '🙈 Ocultar' : '👁 Mostrar');
-            });
-        }
+	$(document).ready(function () {
+		const $toggleBtn = $('#toggle_secret');
+		const $secretField = $('#meli_secret_key');
+
+		if ($toggleBtn.length && $secretField.length) {
+			$toggleBtn.on('click', function () {
+				const isPassword = $secretField.attr('type') === 'password';
+				$secretField.attr('type', isPassword ? 'text' : 'password');
+				$(this).text(isPassword ? '🙈 Ocultar' : '👁 Mostrar');
+			});
+		}
 
 		// Manejo del guardado de SKU con temporizador y opción de cancelar
 		document.querySelectorAll('.sku-selector').forEach(function (select) {
@@ -69,13 +69,13 @@
 								'Content-Type': 'application/json',
 								'X-WP-Nonce': wc_integraciones_admin.rest_nonce
 							},
-							body: JSON.stringify({detalle_id: detalleId, publicacion_id: pubId, sku})
+							body: JSON.stringify({ detalle_id: detalleId, publicacion_id: pubId, sku })
 						}).then(r => r.json()).then(data => {
 							timerSpan.textContent = data.success ? '✅ Guardado' : '❌ Error';
 						})
-						.catch(() => {
-							timerSpan.textContent = '❌ Error. Inténtalo de nuevo.';
-						});
+							.catch(() => {
+								timerSpan.textContent = '❌ Error. Inténtalo de nuevo.';
+							});
 					} else {
 						timerSpan.textContent = `Guardando en ${counter}s...`;
 					}
@@ -88,6 +88,55 @@
 				};
 			});
 		});
-    });
 
-})( jQuery );
+		// Toggle de sincronización de stock hacia Mercado Libre
+		document.querySelectorAll('.toggle-sync-btn').forEach(function (btn) {
+			btn.addEventListener('click', function (e) {
+				e.preventDefault();
+
+				const detalleId = this.dataset.detalleId || null;
+				const publicacionId = this.dataset.publicacionId || null;
+				const currentEnabled = parseInt(this.dataset.enabled, 10);
+				const newEnabled = currentEnabled ? 0 : 1;
+
+				btn.disabled = true;
+				btn.textContent = 'Guardando...';
+
+				fetch('/wp-json/meli/v1/toggle-sync', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-WP-Nonce': wc_integraciones_admin.rest_nonce
+					},
+					body: JSON.stringify({
+						detalle_id: detalleId,
+						publicacion_id: publicacionId,
+						enabled: newEnabled
+					})
+				})
+					.then(r => r.json())
+					.then(data => {
+						if (data.success) {
+							btn.dataset.enabled = newEnabled;
+							btn.textContent = newEnabled ? 'Sincronización: ON' : 'Sincronización: OFF';
+							if (newEnabled) {
+								btn.classList.add('button-primary');
+							} else {
+								btn.classList.remove('button-primary');
+							}
+						} else {
+							btn.textContent = '❌ Error al guardar';
+						}
+					})
+					.catch(() => {
+						btn.textContent = '❌ Error de red';
+					})
+					.finally(() => {
+						btn.disabled = false;
+					});
+			});
+		});
+
+	});
+
+})(jQuery);

--- a/admin/partials/mercadolibre/log/view.php
+++ b/admin/partials/mercadolibre/log/view.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Vista para la pestaña de Log de Inventario
+ */
+?>
+
+<h2>Log de Cambios en Inventario</h2>
+
+<table class="widefat striped" style="margin-top:20px;">
+    <thead>
+        <tr>
+            <th>Fecha</th>
+            <th>SKU</th>
+            <th>Origen</th>
+            <th>Stock Anterior</th>
+            <th>Stock Nuevo</th>
+            <th>Inhibido (Sinc Meli)</th>
+            <th>Descripción</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php if (empty($logs)): ?>
+            <tr>
+                <td colspan="7">No hay registros de inventario.</td>
+            </tr>
+        <?php else: ?>
+            <?php foreach ($logs as $log): ?>
+                <tr>
+                    <td><?php echo esc_html($log->created_at); ?></td>
+                    <td><strong><?php echo esc_html($log->sku); ?></strong></td>
+                    <td>
+                        <?php if ($log->origin === 'meli'): ?>
+                            <span class="dashicons dashicons-cart" title="Mercado Libre"></span> ML
+                        <?php else: ?>
+                            <span class="dashicons dashicons-admin-home" title="WooCommerce"></span> WC
+                        <?php endif; ?>
+                    </td>
+                    <td><?php echo ($log->old_stock !== null) ? esc_html($log->old_stock) : '-'; ?></td>
+                    <td><?php echo esc_html($log->new_stock); ?></td>
+                    <td>
+                        <?php if ($log->inhibir_sincronizacion_meli): ?>
+                            <span style="color:red; font-weight:bold;">SÍ</span>
+                        <?php else: ?>
+                            <span style="color:green;">NO</span>
+                        <?php endif; ?>
+                    </td>
+                    <td><?php echo esc_html($log->description); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </tbody>
+</table>

--- a/admin/partials/mercadolibre/meli2wc/view.php
+++ b/admin/partials/mercadolibre/meli2wc/view.php
@@ -99,6 +99,17 @@
                                                 <?php endforeach; ?>
                                             </select>
                                             <button class="cancel-btn button" style="display:none;">Cancelar</button>
+                                            
+                                            <?php if (!empty($var['wc_sku'])): ?>
+                                                <div style="margin-top: 5px;">
+                                                    <button class="toggle-sync-btn button <?php echo $var['sync_stock_enabled'] ? 'button-primary' : ''; ?>" 
+                                                            data-detalle-id="<?php echo $var['detalle_id']; ?>" 
+                                                            data-enabled="<?php echo $var['sync_stock_enabled']; ?>">
+                                                        <?php echo $var['sync_stock_enabled'] ? 'Sincronización: ON' : 'Sincronización: OFF'; ?>
+                                                    </button>
+                                                </div>
+                                            <?php endif; ?>
+
                                             <span class="save-timer" style="margin-left:5px;color:#666;display:block;"></span>
                                         <?php endif; ?>
                                     </td>
@@ -128,6 +139,17 @@
                                     <?php endforeach; ?>
                                 </select>
                                 <button class="cancel-btn button" style="display:none;">Cancelar</button>
+
+                                <?php if (!empty($pub['wc_sku'])): ?>
+                                    <div style="margin-top: 5px;">
+                                        <button class="toggle-sync-btn button <?php echo $pub['sync_stock_enabled'] ? 'button-primary' : ''; ?>" 
+                                                data-publicacion-id="<?php echo esc_attr($pub['publicacion_id']); ?>" 
+                                                data-enabled="<?php echo $pub['sync_stock_enabled']; ?>">
+                                            <?php echo $pub['sync_stock_enabled'] ? 'Sincronización: ON' : 'Sincronización: OFF'; ?>
+                                        </button>
+                                    </div>
+                                <?php endif; ?>
+
                                 <span class="save-timer" style="margin-left:5px;color:#666;"></span>
                             <?php endif; ?>
                         </div>

--- a/includes/class-wc-integraciones-activator.php
+++ b/includes/class-wc-integraciones-activator.php
@@ -67,6 +67,7 @@ class Wc_Integraciones_Activator {
 			status VARCHAR(50),
 			logistic_type VARCHAR(50),
 			wc_sku VARCHAR(100),
+			sync_stock_enabled TINYINT(1) DEFAULT 0,
 			date_created DATETIME DEFAULT CURRENT_TIMESTAMP
 		) $charset_collate;";
 
@@ -82,6 +83,7 @@ class Wc_Integraciones_Activator {
 			sold_quantity INT,
 			user_product_id VARCHAR(100),
 			wc_sku VARCHAR(100),
+			sync_stock_enabled TINYINT(1) DEFAULT 0,
 			FOREIGN KEY (publicacion_id) REFERENCES $table_publicaciones(id) 
 				ON DELETE CASCADE
 		) $charset_collate;";
@@ -120,6 +122,20 @@ class Wc_Integraciones_Activator {
 			INDEX idx_created (created_at)
 		) $charset_collate;";
 
+		// Tabla Log de Inventario
+		$table_log = $wpdb->prefix . 'wc_integraciones_meli_log_inventario';
+		$sql5 = "CREATE TABLE IF NOT EXISTS $table_log (
+			id BIGINT AUTO_INCREMENT PRIMARY KEY,
+			product_id BIGINT,
+			sku VARCHAR(100),
+			origin VARCHAR(20),
+			old_stock INT,
+			new_stock INT,
+			inhibir_sincronizacion_meli TINYINT(1) DEFAULT 0,
+			description TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		) $charset_collate;";
+
 
 		require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
 		dbDelta($sql);
@@ -127,5 +143,6 @@ class Wc_Integraciones_Activator {
 		dbDelta($sql2);
 		dbDelta($sql3);
 		dbDelta($sql4);
+		dbDelta($sql5);
 	}
 }

--- a/includes/class-wc-integraciones-meli.php
+++ b/includes/class-wc-integraciones-meli.php
@@ -80,4 +80,55 @@ class WC_Integraciones_Meli {
 
         return $body['access_token'];
     }
+
+    /**
+     * Actualiza el stock de un item o una variación en Mercado Libre.
+     * 
+     * @param string $meli_item_id El ID del item en Mercado Libre (e.g., MLA12345678).
+     * @param int|null $variation_id El ID de la variación (opcional).
+     * @param int $new_stock La nueva cantidad disponible.
+     * @return array|bool Respuesta de la API o false en caso de error.
+     */
+    public function actualizar_stock($meli_item_id, $variation_id, $new_stock) {
+        $access_token = $this->obtener_token();
+        if (!$access_token) {
+            return false;
+        }
+
+        $url = "https://api.mercadolibre.com/items/{$meli_item_id}";
+        if ($variation_id) {
+            $url .= "/variations/{$variation_id}";
+        }
+
+        $body = [
+            'available_quantity' => $new_stock
+        ];
+
+        error_log("🚀 Enviando actualización de stock a ML: ID={$meli_item_id}, Variación=" . ($variation_id ?: "N/A") . ", Nuevo Stock={$new_stock}");
+
+        $response = wp_remote_request($url, [
+            'method'  => 'PUT',
+            'headers' => [
+                'Authorization' => 'Bearer ' . $access_token,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode($body)
+        ]);
+
+        if (is_wp_error($response)) {
+            error_log('❌ Error al actualizar stock en ML: ' . $response->get_error_message());
+            return false;
+        }
+
+        $status_code = wp_remote_retrieve_response_code($response);
+        $response_body = json_decode(wp_remote_retrieve_body($response), true);
+
+        if ($status_code < 200 || $status_code >= 300) {
+            error_log('❌ Error en respuesta de ML (Status ' . $status_code . '): ' . wp_json_encode($response_body));
+            return false;
+        }
+
+        error_log('✅ Stock actualizado exitosamente en Mercado Libre.');
+        return $response_body;
+    }
 }

--- a/public/class-wc-integraciones-public.php
+++ b/public/class-wc-integraciones-public.php
@@ -49,6 +49,12 @@ class Wc_Integraciones_Public {
 	 */
 	private $ngrok_url;
 
+    /**
+     * Propiedad para inhibir la sincronización hacia Mercado Libre
+     * Evita bucles infinitos cuando el stock se actualiza desde un webhook de ML.
+     */
+    public static $inhibir_sincronizacion_meli = false;
+
 	/**
 	 * Initialize the class and set its properties.
 	 *
@@ -73,6 +79,18 @@ class Wc_Integraciones_Public {
 			10,
 			1
 		);
+
+        // Acción para sincronizar stock hacia Mercado Libre (asíncrona)
+        add_action(
+            'wc_integraciones_sincronizar_stock_meli',
+            [$this, 'sincronizar_stock_meli_handler'],
+            10,
+            1
+        );
+
+        // Hooks de WooCommerce para detectar cambios de stock
+        add_action('woocommerce_updated_product_stock', [$this, 'handle_wc_stock_change'], 10, 1);
+        add_action('woocommerce_product_object_updated_props', [$this, 'handle_wc_stock_props_change'], 10, 2);
 
 		$this->ngrok_url = WC_Integraciones_Config::get('api_ngrok_url', '');
 	}
@@ -450,13 +468,119 @@ class Wc_Integraciones_Public {
 			$current_stock = (int) $product->get_stock_quantity();
 			$new_stock = max(0, $current_stock - $quantity);
 
+			// Activar inhibición para evitar que el cambio en WC dispare una actualización de vuelta a ML
+            self::$inhibir_sincronizacion_meli = true;
+
 			$product->set_stock_quantity($new_stock);
 			$product->save();
+
+            // Desactivar inhibición
+            self::$inhibir_sincronizacion_meli = false;
 
 			error_log("✅ Stock actualizado para SKU {$detalle->wc_sku}: {$current_stock} → {$new_stock} (venta de {$quantity} unidades)");
 		}
 
 		return ['success' => true, 'message' => 'Procesamiento completado.', 'response' => $order_data];
 	}
+
+    /**
+     * Handler para el hook 'woocommerce_updated_product_stock'
+     */
+    public function handle_wc_stock_change($product_id) {
+        if (self::$inhibir_sincronizacion_meli) {
+            error_log("🚫 Sincronización hacia ML inhibida (cambio originado en ML) para ID: $product_id");
+            return;
+        }
+        $this->schedule_stock_sync($product_id);
+    }
+
+    /**
+     * Handler para el hook 'woocommerce_product_object_updated_props'
+     * Detecta cambios manuales en el objeto producto (incluyendo stock)
+     */
+    public function handle_wc_stock_props_change($product, $updated_props) {
+        if (self::$inhibir_sincronizacion_meli) {
+            return;
+        }
+
+        if (in_array('stock_quantity', $updated_props)) {
+            $product_id = $product->get_id();
+            error_log("📝 Cambio manual de stock detectado para ID: $product_id");
+            $this->schedule_stock_sync($product_id);
+        }
+    }
+
+    /**
+     * Programa la tarea asíncrona en Action Scheduler
+     */
+    private function schedule_stock_sync($product_id) {
+        if (function_exists('as_enqueue_async_action')) {
+            error_log("⏱️ Programando sincronización de stock a ML para Producto ID: $product_id");
+            as_enqueue_async_action('wc_integraciones_sincronizar_stock_meli', ['product_id' => $product_id], 'meli_sync');
+        } else {
+            error_log('⚠️ Action Scheduler no disponible para sincronización de stock.');
+        }
+    }
+
+    /**
+     * Callback del Action Scheduler para ejecutar la sincronización
+     */
+    public function sincronizar_stock_meli_handler($product_id) {
+        global $wpdb;
+
+        $product = wc_get_product($product_id);
+        if (!$product) {
+            error_log("❌ Producto no encontrado para sincronización: $product_id");
+            return;
+        }
+
+        $sku = $product->get_sku();
+        if (empty($sku)) {
+            error_log("ℹ️ Producto sin SKU, se ignora sincronización a ML: $product_id");
+            return;
+        }
+
+        $new_stock = $product->get_stock_quantity();
+        error_log("🔍 Sincronizando stock para SKU: $sku (Stock WC: $new_stock)");
+
+        // Buscar en la tabla de detalles (variaciones)
+        $table_detalle = $wpdb->prefix . 'wc_integraciones_meli_publicaciones_detalle';
+        $detalle = $wpdb->get_row($wpdb->prepare(
+            "SELECT meli_item_id, variation_id FROM $table_detalle WHERE wc_sku = %s",
+            $sku
+        ));
+
+        $meli_item_id = null;
+        $variation_id = null;
+
+        if ($detalle) {
+            $meli_item_id = $detalle->meli_item_id;
+            $variation_id = $detalle->variation_id;
+        } else {
+            // Buscar en la tabla de publicaciones (productos simples)
+            $table_pub = $wpdb->prefix . 'wc_integraciones_meli_publicaciones';
+            $pub = $wpdb->get_row($wpdb->prepare(
+                "SELECT meli_item_id FROM $table_pub WHERE wc_sku = %s",
+                $sku
+            ));
+            if ($pub) {
+                $meli_item_id = $pub->meli_item_id;
+            }
+        }
+
+        if (!$meli_item_id) {
+            error_log("ℹ️ No se encontró vinculación en ML para SKU: $sku");
+            return;
+        }
+
+        $meli = new WC_Integraciones_Meli();
+        $resultado = $meli->actualizar_stock($meli_item_id, $variation_id, $new_stock);
+
+        if ($resultado) {
+            error_log("✅ Sincronización exitosa WC -> ML para SKU: $sku");
+        } else {
+            error_log("❌ Falló la sincronización WC -> ML para SKU: $sku");
+        }
+    }
 
 }

--- a/public/class-wc-integraciones-public.php
+++ b/public/class-wc-integraciones-public.php
@@ -398,7 +398,7 @@ class Wc_Integraciones_Public {
 		if ($order_data['fulfilled'] === true) {
 			$message = 'ℹ️ La orden ya ha sido cumplida, no se procesará.';
 			error_log($message);
-			return ['success' => true, 'message' => $message, 'response' => $order_data]	;
+			return ['success' => true, 'message' => $message, 'response' => $order_data];
 		}
 
 		if (empty($order_data['order_items'])) {
@@ -460,7 +460,7 @@ class Wc_Integraciones_Public {
 			$product = wc_get_product($product_id);
 
 			if (!$product || !$product->managing_stock()) {
-				error_log("⚠️ El producto con SKU {$detalle->wc_sku} no gestiona inventario o no es válido.");
+				error_log("⚠️ El producto con SKU {$wc_sku} no gestiona inventario o no es válido.");
 				continue;
 			}
 
@@ -472,12 +472,23 @@ class Wc_Integraciones_Public {
             self::$inhibir_sincronizacion_meli = true;
 
 			$product->set_stock_quantity($new_stock);
-			$product->save();
+            $product->save();
+
+            // Registrar Log
+            $this->log_inventory(
+                $product_id,
+                $wc_sku,
+                'meli',
+                $current_stock,
+                $new_stock,
+                1,
+                "Venta de {$quantity} unidades desde Mercado Libre (Item: {$meli_item_id})"
+            );
 
             // Desactivar inhibición
             self::$inhibir_sincronizacion_meli = false;
 
-			error_log("✅ Stock actualizado para SKU {$detalle->wc_sku}: {$current_stock} → {$new_stock} (venta de {$quantity} unidades)");
+			error_log("✅ Stock actualizado para SKU {$wc_sku}: {$current_stock} → {$new_stock} (venta de {$quantity} unidades)");
 		}
 
 		return ['success' => true, 'message' => 'Procesamiento completado.', 'response' => $order_data];
@@ -543,33 +554,56 @@ class Wc_Integraciones_Public {
         $new_stock = $product->get_stock_quantity();
         error_log("🔍 Sincronizando stock para SKU: $sku (Stock WC: $new_stock)");
 
-        // Buscar en la tabla de detalles (variaciones)
+        // Buscar en la tabla de detalles (variaciones) con JOIN a publicaciones para obtener meli_item_id
         $table_detalle = $wpdb->prefix . 'wc_integraciones_meli_publicaciones_detalle';
+        $table_pub = $wpdb->prefix . 'wc_integraciones_meli_publicaciones';
+		
         $detalle = $wpdb->get_row($wpdb->prepare(
-            "SELECT meli_item_id, variation_id FROM $table_detalle WHERE wc_sku = %s",
+            "SELECT p.meli_item_id, d.variation_id, d.sync_stock_enabled 
+             FROM $table_detalle d
+             INNER JOIN $table_pub p ON d.publicacion_id = p.id
+             WHERE d.wc_sku = %s",
             $sku
         ));
 
         $meli_item_id = null;
         $variation_id = null;
+        $sync_enabled = 0;
 
         if ($detalle) {
             $meli_item_id = $detalle->meli_item_id;
             $variation_id = $detalle->variation_id;
+            $sync_enabled = $detalle->sync_stock_enabled;
         } else {
             // Buscar en la tabla de publicaciones (productos simples)
-            $table_pub = $wpdb->prefix . 'wc_integraciones_meli_publicaciones';
             $pub = $wpdb->get_row($wpdb->prepare(
-                "SELECT meli_item_id FROM $table_pub WHERE wc_sku = %s",
+                "SELECT meli_item_id, sync_stock_enabled FROM $table_pub WHERE wc_sku = %s",
                 $sku
             ));
             if ($pub) {
                 $meli_item_id = $pub->meli_item_id;
+                $sync_enabled = $pub->sync_stock_enabled;
             }
         }
 
         if (!$meli_item_id) {
             error_log("ℹ️ No se encontró vinculación en ML para SKU: $sku");
+            return;
+        }
+
+        // Registrar log del intento (indicando si está habilitado o no)
+        $this->log_inventory(
+            $product_id,
+            $sku,
+            'wc',
+            null,
+            $new_stock,
+            self::$inhibir_sincronizacion_meli ? 1 : 0,
+            $sync_enabled ? "Sincronización hacia ML iniciada." : "Sincronización hacia ML ignorada (Desactivado por el usuario)."
+        );
+
+        if (!$sync_enabled) {
+            error_log("🚫 Sincronización desactivada por el usuario para SKU: $sku");
             return;
         }
 
@@ -581,6 +615,24 @@ class Wc_Integraciones_Public {
         } else {
             error_log("❌ Falló la sincronización WC -> ML para SKU: $sku");
         }
+    }
+
+    /**
+     * Helper para registrar cambios de inventario
+     */
+    private function log_inventory($product_id, $sku, $origin, $old_stock, $new_stock, $inhibir, $description) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'wc_integraciones_meli_log_inventario';
+        $wpdb->insert($table, [
+            'product_id' => $product_id,
+            'sku' => $sku,
+            'origin' => $origin,
+            'old_stock' => $old_stock,
+            'new_stock' => $new_stock,
+            'inhibir_sincronizacion_meli' => $inhibir,
+            'description' => $description,
+            'created_at' => current_time('mysql')
+        ]);
     }
 
 }


### PR DESCRIPTION
Add an inventory change log system and a per-SKU control to enable/disable
stock synchronization toward ML.

Database:
- Add `sync_stock_enabled` column to `meli_publicaciones` and
  `meli_publicaciones_detalle` tables (default: disabled).
- Create `meli_log_inventario` table to store inventory change history.

Inventory logging:
- Log stock changes originating from ML orders (procesar_order_v2)
  with inhibition flag set to true.
- Log stock changes originating from WC (sincronizar_stock_meli_handler)
  indicating whether the sync to ML was processed or skipped.

Sync control:
- Block outbound stock updates to ML when `sync_stock_enabled` is 0
  for the matched SKU record.
- Register REST endpoint `meli/v1/toggle-sync` to update the flag per
  detalle or publicación record.

Admin UI:
- Add toggle button in the "Meli a WC" table next to each assigned SKU
  (for both variations and simple products).
- Add JS click handler that calls the toggle endpoint and updates button
  state (ON/OFF) without page reload.
- Add "Log" tab view displaying the last 100 inventory change records
  with origin icons, stock delta, and inhibition status.
